### PR TITLE
Tighten warnings and bring it in line with other code bases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,14 @@ endif()
 list(APPEND RAVL_FLAGS -fPIC)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  list(APPEND RAVL_FLAGS -Wall -pedantic)
+  list(APPEND RAVL_FLAGS -Wall
+                         -Wextra
+                         -Werror
+                         -Wundef
+                         -Wpedantic
+                         -Wno-unused
+                         -Wno-unused-parameter
+                         -Wshadow)
   if(NOT DEFINED SAN)
     set(SAN on)
   endif()

--- a/include/ravl/openssl.hpp
+++ b/include/ravl/openssl.hpp
@@ -2199,8 +2199,8 @@ namespace OpenSSL
         int sz = sk_GENERAL_NAME_num(names);
         if (sz != -1)
         {
-          for (int i = 0; i < sz; i++)
-            r.push(names.at(i));
+          for (int j = 0; j < sz; j++)
+            r.push(names.at(j));
         }
       }
     }

--- a/include/ravl/request_tracker_impl.h
+++ b/include/ravl/request_tracker_impl.h
@@ -63,7 +63,7 @@ namespace ravl
     RequestID submit(
       const Options& options,
       std::shared_ptr<const Attestation> attestation,
-      std::shared_ptr<HTTPClient> http_client,
+      std::shared_ptr<HTTPClient> http_client_,
       std::function<void(RequestID)>&& callback)
     {
       RequestID request_id;
@@ -79,7 +79,7 @@ namespace ravl
           RequestState::SUBMITTED,
           options,
           attestation,
-          http_client,
+          http_client_,
           std::move(callback));
 
         if (!ok)
@@ -204,7 +204,7 @@ namespace ravl
 
       const auto& attestation = *request.attestation;
       const auto& options = request.options;
-      auto http_client = request.http_client;
+      auto http_client_ = request.http_client;
 
       if (options.verbosity > 0)
       {
@@ -257,7 +257,7 @@ namespace ravl
           advance(id);
         };
         request.http_request_set_id =
-          http_client->submit(std::move(*http_requests), callback);
+          http_client_->submit(std::move(*http_requests), callback);
         return true;
       }
 
@@ -271,7 +271,7 @@ namespace ravl
 
       auto& attestation = *request.attestation;
       const auto& options = request.options;
-      auto http_client = request.http_client;
+      auto http_client_ = request.http_client;
 
       std::shared_ptr<Claims> claims;
 

--- a/include/ravl/sgx_impl.h
+++ b/include/ravl/sgx_impl.h
@@ -599,8 +599,8 @@ namespace ravl
             if (t.size() != r.cpu_svn.size())
               throw std::runtime_error(
                 "SGX X509 TCB extension: ASN.1 octet string of invalid size");
-            for (size_t i = 0; i < r.cpu_svn.size(); i++)
-              r.cpu_svn.at(i) = t.at(i);
+            for (size_t j = 0; j < r.cpu_svn.size(); j++)
+              r.cpu_svn.at(j) = t.at(j);
           }
           else
             throw std::runtime_error("unreachable");


### PR DESCRIPTION
This should facilitate usage with more recent versions of other code bases.