### PR TITLE
minor fix

### DIFF
--- a/include/ravl/sgx_impl.h
+++ b/include/ravl/sgx_impl.h
@@ -335,14 +335,12 @@ namespace ravl
         auto tmpl = *options.sgx_endorsement_cache_url_template;
         requests.emplace_back(
           fmt::vformat(tmpl, fmt::make_format_args("pckcrl", root_crl_url)));
+        std::string full_tcb_url = tcb_url + "&fmspc=" + fmspc;
         requests.emplace_back(fmt::vformat(
-          tmpl, fmt::make_format_args("tcb", tcb_url + "&fmspc=" + fmspc)));
+          tmpl, fmt::make_format_args("tcb", full_tcb_url)));
+        std::string full_pckcrl = intel_certificates_url_base + "/intelsgxpck" + ca + ".crl" + "&encoding=pem";
         requests.emplace_back(fmt::vformat(
-          tmpl,
-          fmt::make_format_args(
-            "pckcrl",
-            intel_certificates_url_base + "/intelsgxpck" + ca + ".crl" +
-              "&encoding=pem")));
+          tmpl, fmt::make_format_args("pckcrl", full_pckcrl)));
         if (!qve)
           requests.emplace_back(fmt::vformat(
             tmpl, fmt::make_format_args("qe/identity", qe_identity_url)));


### PR DESCRIPTION
This is a minor fix to support new fmt version that require that second argument of make_format_args to be an lvalue. 